### PR TITLE
(re-) Add New Features in Cash Penalty Environment 

### DIFF
--- a/finrl/env/env_stocktrading_cashpenalty.py
+++ b/finrl/env/env_stocktrading_cashpenalty.py
@@ -21,13 +21,14 @@ class StockTradingEnvCashpenalty(gym.Env):
     This enables the model to manage cash reserves in addition to performing trading procedures. 
 
     Reward at any step is given as follows
-        r_i = (sum(cash + asset_value) - initial_cash - max(0, sum(cash, asset_value)*cash_penalty_proportion-cash))/(days_elapsed)
+        r_i = (sum(cash, asset_value) - initial_cash - max(0, sum(cash, asset_value)*cash_penalty_proportion-cash))/(days_elapsed)
         This reward function takes into account a liquidity requirement, as well as long-term accrued rewards. 
 
     Parameters:
     state space: {start_cash, <owned_shares>, for s in stocks{<stock.values>}, }
         df (pandas.DataFrame): Dataframe containing data
-        transaction_cost (float): cost for buying or selling shares
+        buy_cost_pct (float): cost for buying shares
+        sell_cost_pct (float): cost for selling shares
         hmax (int): max number of share purchases allowed per asset
         discrete_actions (bool): option to choose whether perform dicretization on actions space or not
         shares_increment (int): multiples number of shares can be bought in each trade. Only applicable if discrete_actions=True
@@ -54,7 +55,8 @@ class StockTradingEnvCashpenalty(gym.Env):
     def __init__(
         self,
         df,
-        transaction_cost_pct=3e-3,
+        buy_cost_pct=3e-3,
+        sell_cost_pct=3e-3,
         date_col_name="date",
         hmax=10,
         discrete_actions=False,
@@ -73,13 +75,17 @@ class StockTradingEnvCashpenalty(gym.Env):
         self.assets = df[self.stock_col].unique()
         self.dates = df[date_col_name].sort_values().unique()
         self.random_start = random_start
+        self.discrete_actions = discrete_actions
+        self.currency = currency
 
         self.df = self.df.set_index(date_col_name)
         self.shares_increment = shares_increment
         self.hmax = hmax
         self.initial_amount = initial_amount
         self.print_verbosity = print_verbosity
-        self.transaction_cost_pct = transaction_cost_pct
+        self.buy_cost_pct = buy_cost_pct
+        self.sell_cost_pct = sell_cost_pct
+        self.turbulence_threshold = turbulence_threshold
         self.daily_information_cols = daily_information_cols
         self.state_space = (
             1 + len(self.assets) + len(self.assets) * len(self.daily_information_cols)
@@ -88,6 +94,7 @@ class StockTradingEnvCashpenalty(gym.Env):
         self.observation_space = spaces.Box(
             low=-np.inf, high=np.inf, shape=(self.state_space,)
         )
+        self.turbulence = 0 
         self.episode = -1  # initialize so we can call reset
         self.episode_history = []
         self.printed_header = False
@@ -119,6 +126,7 @@ class StockTradingEnvCashpenalty(gym.Env):
         else:
             self.starting_point = 0
         self.date_index = self.starting_point
+        self.turbulence = 0
         self.episode += 1
         self.actions_memory = []
         self.transaction_memory = []
@@ -160,8 +168,13 @@ class StockTradingEnvCashpenalty(gym.Env):
         logger.record("environment/total_assets", int(self.account_information['total_assets'][-1]))
         reward_pct = self.account_information["total_assets"][-1] / self.initial_amount
         logger.record("environment/total_reward_pct", (reward_pct - 1) * 100)
+        logger.record("environment/total_trades", self.sum_trades)
         logger.record(
-            "environment/daily_trades",
+            "environment/avg_daily_trades",
+            self.sum_trades / (self.current_step),
+        )
+        logger.record(
+            "environment/avg_daily_trades_per_asset",
             self.sum_trades / (self.current_step) / len(self.assets),
         )
         logger.record("environment/completed_steps", self.current_step)
@@ -182,6 +195,7 @@ class StockTradingEnvCashpenalty(gym.Env):
             self.account_information["cash"][-1]
             / self.account_information["total_assets"][-1]
         )
+        gl_pct = self.account_information["total_assets"][-1] / self.initial_amount
         rec = [
             self.episode,
             self.date_index - self.starting_point,
@@ -189,6 +203,7 @@ class StockTradingEnvCashpenalty(gym.Env):
             f"{self.currency}{'{:0,.0f}'.format(float(self.account_information['cash'][-1]))}",
             f"{self.currency}{'{:0,.0f}'.format(float(self.account_information['total_assets'][-1]))}",
             f"{terminal_reward*100:0.5f}%",
+            f"{(gl_pct - 1)*100:0.5f}%",
             f"{cash_pct*100:0.2f}%",
         ]
 
@@ -196,15 +211,17 @@ class StockTradingEnvCashpenalty(gym.Env):
         print(self.template.format(*rec))
 
     def log_header(self):
-        self.template = "{0:4}|{1:4}|{2:15}|{3:10}|{4:10}|{5:10}"  # column widths: 8, 10, 15, 7, 10
+        self.template = "{0:4}|{1:4}|{2:15}|{3:15}|{4:15}|{5:10}|{6:10}|{7:10}"  # column widths: 8, 10, 15, 7, 10
         print(
             self.template.format(
                 "EPISODE",
                 "STEPS",
                 "TERMINAL_REASON",
+                "CASH",
                 "TOT_ASSETS",
                 "TERMINAL_REWARD_unsc",
-                "CASH_PCT",
+                "GAINLOSS_PCT",
+                "CASH_PROPORTION",
             )
         )
         self.printed_header = True
@@ -255,16 +272,28 @@ class StockTradingEnvCashpenalty(gym.Env):
             self.account_information["reward"].append(reward)
 
             # multiply action values by our scalar multiplier and save
-            actions = actions * self.hmax
-            self.actions_memory.append(actions)
+            actions = actions * self.hmax 
+            self.actions_memory.append(actions*closings) #capture what the model's trying to do
 
-            # scale cash purchases to asset # changes
-            actions = actions / closings
+            #buy/sell only if the price is > 0 (no missing data in this particular date) 
+            actions = np.where(closings>0,actions,0)
+
+            if self.turbulence_threshold is not None:
+                # if turbulence goes over threshold, just clear out all positions
+                if self.turbulence>=self.turbulence_threshold:
+                    actions = -(np.array(holdings) * closings)
+                    self.log_step(reason="TURBULENCE")
+
+            # scale cash purchases to asset
+            if self.discrete_actions:
+                #convert into integer because we can't buy fraction of shares
+                actions = np.where(closings>0,actions//closings,0)
+                actions = (actions.astype(int))
+            else:
+                actions = np.where(closings>0,actions/closings,0)
             
-
             # clip actions so we can't sell more assets than we hold
             actions = np.maximum(actions, -np.array(holdings))
-            self.transaction_memory.append(actions)
 
             # round down actions to the nearest multiplies of shares_increment
             actions = (actions//self.shares_increment)*self.shares_increment
@@ -274,13 +303,13 @@ class StockTradingEnvCashpenalty(gym.Env):
             # compute our proceeds from sells, and add to cash
             sells = -np.clip(actions, -np.inf, 0)
             proceeds = np.dot(sells, closings)
-            costs = proceeds * self.transaction_cost_pct
+            costs = proceeds * self.sell_cost_pct
             coh = begin_cash + proceeds
 
             # compute the cost of our buys
             buys = np.clip(actions, 0, np.inf)
             spend = np.dot(buys, closings)
-            costs += spend * self.transaction_cost_pct
+            costs += spend * self.buy_cost_pct
 
             # if we run out of cash, end the cycle and penalize
             if (spend + costs) > coh:
@@ -295,11 +324,17 @@ class StockTradingEnvCashpenalty(gym.Env):
             # update our holdings
             coh = coh - spend - costs
             holdings_updated = holdings + actions
+
             self.date_index += 1
+            if self.turbulence_threshold is not None:     
+                self.turbulence = self.get_date_vector(self.date_index,cols=["turbulence"])[0]
+
+            #Update State
             state = (
                 [coh] + list(holdings_updated) + self.get_date_vector(self.date_index)
             )
             self.state_memory.append(state)
+
             return state, reward, False, {}
 
     def get_sb_env(self):


### PR DESCRIPTION
Add Features in env_stocktrading_cashpenalty.py:

1. Split `transaction_cost_pct` to `buy_cost_pct` and `sell_cost_pct`
2. Add optional actions discretization parameter: `discrete_actions`
3. Incorporate different length of data in multi stock trading
4. Minor fixing in class docs
5. Activate turbulence
6. Add `currency` parameter
7. Enrich logging information
8. Add optional `shares_increment` parameter. Now, we can handle the multiplies number of shares can be bought by using this parameter. 