### PR TITLE
Fix error in save_action_memory function ...

### DIFF
--- a/finrl/env/env_stocktrading.py
+++ b/finrl/env/env_stocktrading.py
@@ -75,8 +75,6 @@ class StockTradingEnv(gym.Env):
         #self.reset()
         self._seed()
         
-
-
     def _sell_stock(self, index, action):
         def _do_sell_normal():
             if self.state[index+1]>0: 
@@ -125,7 +123,6 @@ class StockTradingEnv(gym.Env):
             sell_num_shares = _do_sell_normal()
 
         return sell_num_shares
-
     
     def _buy_stock(self, index, action):
 
@@ -354,7 +351,7 @@ class StockTradingEnv(gym.Env):
     def save_action_memory(self):
         if len(self.df.tic.unique())>1:
             # date and close price length must match actions length
-            date_list = self.date_memory[:-1]
+            date_list = self.date_memory
             df_date = pd.DataFrame(date_list)
             df_date.columns = ['date']
             


### PR DESCRIPTION
- Assigning 'date' column to `df_date` not working due to 
```*** ValueError: Length mismatch: Expected axis has 0 elements, new values have 1 elements```

I ran into this error in the `FinRL_multiple_stock_trading` notebook in the **Trading** section and within the `DRL_prediction` function.