### PR TITLE
Add patient features in cash penalty env

### DIFF
--- a/finrl/env/env_stocktrading_cashpenalty.py
+++ b/finrl/env/env_stocktrading_cashpenalty.py
@@ -288,10 +288,17 @@ class StockTradingEnvCashpenalty(gym.Env):
             costs += spend * self.buy_cost_pct
              # if we run out of cash...
             if (spend + costs) > coh:
-                # ... end the cycle and penalize
-                return self.return_terminal(
-                    reason="CASH SHORTAGE",reward=self.get_reward()
-                )
+                if self.patient:
+                    # ... just don't buy anything until we got additional cash
+                    self.log_step(reason="CASH SHORTAGE")
+                    actions = np.where(actions>0,0,actions)
+                    spend = 0
+                    costs = 0
+                else:
+                    # ... end the cycle and penalize
+                    return self.return_terminal(
+                        reason="CASH SHORTAGE",reward=self.get_reward()
+                    )
             self.transaction_memory.append(actions)  # capture what the model's could do
             # verify we didn't do anything impossible here
             assert (spend + costs) <= coh

--- a/tests/test_env/test_env_cashpenalty.py
+++ b/tests/test_env/test_env_cashpenalty.py
@@ -67,6 +67,23 @@ class TestStocktradingEnvCashpenalty(unittest.TestCase):
         self.assertEqual(holdings[0], 10.0)
         self.assertEqual(holdings[1], 0.0)
 
+    def test_patient(self):
+        # Prove that we just not buying any new assets if running out of cash and the cycle is not ended
+        aapl_first_close = self.df[self.df['tic']=='AAPL'].head(1)['close'].values[0]
+        init_amt = aapl_first_close
+        hmax = aapl_first_close * 100
+        env = StockTradingEnvCashpenalty(
+            df=self.df, initial_amount=init_amt, hmax=hmax,
+            cache_indicator_data=False,patient=True,
+            random_start=False, 
+        )
+        _ = env.reset()
+
+        actions = np.array([1.0,1.0])
+        next_state, _, is_done, _ = env.step(actions)
+        holdings = next_state[1 : 1 + len(self.ticker_list)]
+        self.assertEqual(False, is_done)
+        self.assertEqual(0.0, np.sum(holdings))
 
     def test_cost_penalties(self):
         # TODO: Requesting contributions!


### PR DESCRIPTION
Add `patient` parameter to control whether we have to end the cycle when we're running out of cash or just don't buy anything until we got additional cash