### PR TITLE
Add French Index CAC40 to available tickers

### DIFF
--- a/finrl/config/config.py
+++ b/finrl/config/config.py
@@ -1165,6 +1165,51 @@ CSI_300_TICKER = [
     "300628.SZ",
 ]
 
+# Check https://www.bnains.org/archives/histocac/compocac.php for CAC 40 constituents
+# CAC 40 constituents at 2019/01
+CAC_40_TICKER = [
+    "AC.PA",
+    "AI.PA",
+    "AIR.PA",
+    "MT.AS",
+    "ATO.PA",
+    "CS.PA",
+    "BNP.PA",
+    "EN.PA",
+    "CAP.PA",
+    "CA.PA",
+    "ACA.PA",
+    "BN.PA",
+    "DSY.PA",
+    "ENGI.PA",
+    "EL.PA",
+    "RMS.PA",
+    "KER.PA",
+    "OR.PA",
+    "LR.PA",
+    "MC.PA",
+    "ML.PA",
+    "ORA.PA",
+    "RI.PA",
+    "PUGOY",
+    "PUB.PA",
+    "RNO.PA",
+    "SAF.PA",
+    "SGO.PA",
+    "SAN.PA",
+    "SU.PA",
+    "GLE.PA",
+    "SW.PA",
+    "STM.PA",
+    "FTI.PA",
+    "FP.PA",
+    "URW.AS",
+    "FR.PA",
+    "VIE.PA",
+    "DG.PA",
+    "VIV.PA",
+]
+
 ############## Stock Ticker Setup ends ##############
 
 ###Jan 20,2020, added by YuQing Huang###################


### PR DESCRIPTION
Hello !
French index CAC40 is a major index and it would be nice to have it directly defined in FinRL.
I propose to add it directly in config.py to make it available.

This list of CAC40 constituents is made as of 2019-01-01 like others FinRL tickers.
I added the source (a website maintained by a finance enthousiast) for the composition as there is no official source (Euronext) that gives old compositions of CAC40 at a specific date.

One symbol was part of the CAC40 on January 1, 2019 (Peugeot) and was delisted on January 17, 2020, following a merger (Peugeot became Stellantis after the merger with Fiat Chrysler). However, the new entity Stellantis (STLA.PA) has no pre-listing adjusted price for historization purposes on Yahoo Finance! Therefore, I propose, to ensure the continuity of the backtest, to use the OTC Instrument PUGOY that followed the price of Peugeot and now Stellantis.