### PR TITLE
Preprocessor Bug Fixing

### DIFF
--- a/finrl/preprocessing/preprocessors.py
+++ b/finrl/preprocessing/preprocessors.py
@@ -64,12 +64,13 @@ class FeatureEngineer:
 
     def add_technical_indicator(self, data):
         """
-        calcualte technical indicators
+        calculate technical indicators
         use stockstats package to add technical inidactors
         :param data: (df) pandas dataframe
         :return: (df) pandas dataframe
         """
         df = data.copy()
+        df = df.sort_values(by=['tic','date'])
         stock = Sdf.retype(df.copy())
         unique_ticker = stock.tic.unique()
 
@@ -79,12 +80,15 @@ class FeatureEngineer:
                 try:
                     temp_indicator = stock[stock.tic == unique_ticker[i]][indicator]
                     temp_indicator = pd.DataFrame(temp_indicator)
+                    temp_indicator['tic'] = unique_ticker[i]
+                    temp_indicator['date'] = df[df.tic == unique_ticker[i]]['date'].to_list()
                     indicator_df = indicator_df.append(
                         temp_indicator, ignore_index=True
                     )
                 except Exception as e:
                     print(e)
-            df[indicator] = indicator_df
+            df = df.merge(indicator_df[['tic','date',indicator]],on=['tic','date'],how='left')
+        df = df.sort_values(by=['date','tic'])
         return df
 
     def add_user_defined_feature(self, data):


### PR DESCRIPTION
Solving Issue [#186](https://github.com/AI4Finance-LLC/FinRL-Library/issues/186)

Fixing prev. implementation of `add_technical_indicator` function bug (time-series not matched)

Here's the output using prev. implementation. As you can see, it doesn't make sense that the lower band of Bollinger Band Indicator looks like that.
![image](https://user-images.githubusercontent.com/53264414/111896549-11c26700-8a4d-11eb-9d8d-fdc01e83471b.png)

And here's the output using the revised function.
![image](https://user-images.githubusercontent.com/53264414/111896551-1424c100-8a4d-11eb-9d6d-acfeb5bde4da.png)
